### PR TITLE
#39: Bump required "catalog" version to 3.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     "require": {
         "php": "~7.0.0",
         "ext-gd": "*",
-        "lizards-and-pumpkins/catalog": "~3.0.0"
+        "lizards-and-pumpkins/catalog": "~3.1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7",
+        "phpunit/phpunit": "^6.0",
         "lizards-and-pumpkins/coding-standards": "dev-master"
     },
     "autoload" : {


### PR DESCRIPTION
Closes #39.